### PR TITLE
Update MediaPipe install command to v0.10.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Press the `Esc` key to exit.
 ```
 pip install pygame 
 pip install opencv-python
-pip install git+https://github.com/google-ai-edge/mediapipe.git@v0.8.9
+pip install git+https://github.com/google-ai-edge/mediapipe.git@v0.10.14
 ```
 
 ### Pyinstaller (package game into an executable)


### PR DESCRIPTION
### Motivation
- Update the project documentation to reference a newer MediaPipe release and provide users with the current install command `git+https://github.com/google-ai-edge/mediapipe.git@v0.10.14`.

### Description
- Modified the MediaPipe install line in `README.md` to replace `@v0.8.9` with `@v0.10.14`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac9c1b8c0833196528c80ffc06ddb)