### PR TITLE
Migrate pose tracking to MediaPipe Tasks API and add model asset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Press the `Esc` key to exit.
 ```
 pip install pygame 
 pip install opencv-python
-pip install git+https://github.com/google-ai-edge/mediapipe.git@v0.8.9
+pip install git+https://github.com/google-ai-edge/mediapipe.git@v0.10.14
 ```
 
 ### Pyinstaller (package game into an executable)

--- a/scripts/calculations.py
+++ b/scripts/calculations.py
@@ -69,19 +69,20 @@ def colliding_fruit(point1: tuple, fruit):
 
 # add left and right index and pinky pose landmarks if they exist
 def knife_trails_and_find_hands(
-    results, 
-    left_knife_trail, 
+    results,
+    left_knife_trail,
     right_knife_trail,
-    width, 
+    width,
     height) -> tuple:
     left_hand_is_visible = True
     right_hand_is_visible = True
 
     if results.pose_landmarks:
-        left_pinky = results.pose_landmarks.landmark[17]
-        left_index = results.pose_landmarks.landmark[19]
-        right_pinky = results.pose_landmarks.landmark[18]
-        right_index = results.pose_landmarks.landmark[20]
+        landmarks = results.pose_landmarks[0]
+        left_pinky = landmarks[17]
+        left_index = landmarks[19]
+        right_pinky = landmarks[18]
+        right_index = landmarks[20]
 
         if left_pinky.visibility >= 1 and left_index.visibility >= 1:
             left_hand_is_visible = True
@@ -104,22 +105,23 @@ def knife_trails_and_find_hands(
     else:
         return None, None
 
-def find_and_draw_pose(pose, frame, background) -> tuple:
+def find_and_draw_pose(pose, frame, background, timestamp_ms) -> tuple:
     background = background.copy()
 
     # used for mediapipe to detect pose
     image_to_process = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
-    # improve performance by optionally marking image as not writeable
-    image_to_process.flags.writeable = False
-    results = pose.process(image_to_process)
+    mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=image_to_process)
+    results = pose.detect_for_video(mp_image, timestamp_ms)
 
     # draw pose
-    MP_DRAWING.draw_landmarks(
-        background,
-        results.pose_landmarks,
-        MP_POSE.POSE_CONNECTIONS,
-        landmark_drawing_spec=MP_DRAWING_STYLES.get_default_pose_landmarks_style())
+    if results.pose_landmarks:
+        for pose_landmarks in results.pose_landmarks:
+            MP_DRAWING.draw_landmarks(
+                background,
+                pose_landmarks,
+                MP_POSE.POSE_CONNECTIONS,
+                landmark_drawing_spec=MP_DRAWING_STYLES.get_default_pose_landmarks_style())
     return results, background
 
 def array_img_to_pygame(img, width, height):


### PR DESCRIPTION
### Motivation
- Make the project compatible with newer MediaPipe releases by replacing legacy `mp.solutions.pose` usage with the Tasks API. 
- Ensure the PoseLandmarker model asset is available at runtime so the new API can be used without manual setup. 
- Update documentation to reference the newer MediaPipe install command already prepared in the repo.

### Description
- Replaced usage of `mp.solutions.pose` with the Tasks API by importing `from mediapipe.tasks import python as mp_python` and `from mediapipe.tasks.python import vision`, and using `vision.PoseLandmarker.create_from_options` to create the pose landmarker. 
- Added `ensure_pose_landmarker_model()` to `scripts/fruit_ninja.py` to download and store the `pose_landmarker_lite.task` asset under `models/` using `urllib.request.urlretrieve`, and wired the model path into `mp_python.BaseOptions`. 
- Updated pose processing to the Tasks API result shapes: changed `find_and_draw_pose` to accept a `timestamp_ms` and call `pose.detect_for_video(mp.Image(...), timestamp_ms)`, and updated `knife_trails_and_find_hands` to read landmarks from `results.pose_landmarks[0]` and adapt visibility/coordinate handling. 
- Small README change to recommend the newer MediaPipe install (`git+https://github.com/google-ai-edge/mediapipe.git@v0.10.14`).

### Testing
- Ran `python -m py_compile scripts/fruit_ninja.py scripts/calculations.py` which completed successfully with no syntax errors. 
- No other automated tests were available or executed for runtime verification of the model download or live webcam behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac9c1b8c0833196528c80ffc06ddb)